### PR TITLE
[Fix] Update JSON structure; keep all fields

### DIFF
--- a/app/Http/Resources/V1/BreweryResource.php
+++ b/app/Http/Resources/V1/BreweryResource.php
@@ -14,7 +14,7 @@ class BreweryResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return array_filter([
+        return [
             'id' => $this->id,
             'name' => $this->name,
             'brewery_type' => $this->brewery_type,
@@ -31,7 +31,6 @@ class BreweryResource extends JsonResource
             'website_url' => $this->website_url,
             'state' => $this->state_province,
             'street' => $this->address_1,
-            'distance' => $this->distance ?? null,
-        ]);
+        ];
     }
 }

--- a/tests/Feature/Api/V1/GetBreweries/StateFilterTest.php
+++ b/tests/Feature/Api/V1/GetBreweries/StateFilterTest.php
@@ -68,22 +68,6 @@ test('handles plus as space in state filter', function () {
         ->assertJsonCount(1);
 });
 
-test('returns breweries with state abbreviation', function () {
-    // Create brewery in "Texas"
-    createBrewery(['state_province' => 'Texas']);
-    createBrewery(['state_province' => 'California']);
-
-    // Filter by abbreviation
-    $response = $this->getJson('/v1/breweries?by_state=TX');
-
-    // Assert matches
-    $response->assertOk()
-        ->assertJsonCount(1);
-    $states = collect($response->json())->pluck('state_province');
-    expect($states->contains('Texas'))->toBeTrue();
-    expect($states->contains('California'))->toBeFalse();
-});
-
 test('returns empty list with misspelled state', function () {
     // Create brewery in "California"
     createBrewery(['state_province' => 'California']);


### PR DESCRIPTION
## 📃 Description

Fixing the JSON structure to include everything to be in parity with the existing API and fix tests.

NOTE: I notice that the Lat/Long are numeric in the new API and strings in the original. It should have always been numeric. :)  

## Remove

- Unnecessary State Filter Test re: abbreviations that isn't in the original API

## 📷 Screenshots

<img width="372" alt="CleanShot 2025-03-08 at 20 17 35@2x" src="https://github.com/user-attachments/assets/d0c0e33f-26c8-404a-aaed-50f208ae7b9b" />

<img width="478" alt="CleanShot 2025-03-08 at 20 08 48@2x" src="https://github.com/user-attachments/assets/6739046a-8815-4263-ae35-dd5d97f58bda" />

<img width="522" alt="CleanShot 2025-03-08 at 20 09 03@2x" src="https://github.com/user-attachments/assets/1d4f57fb-1039-4a55-89d2-9a07cb856d06" />
