### PR TITLE
[Bug] Implement brewery type validation and update request handling

### DIFF
--- a/app/Http/Controllers/Api/V1/ListBreweries.php
+++ b/app/Http/Controllers/Api/V1/ListBreweries.php
@@ -29,19 +29,9 @@ class ListBreweries extends Controller
             'by_name' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
             'by_postal' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
             'by_state' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
-            'by_type' => [
-                'sometimes',
-                'required',
-                'string',
-                new BreweryTypeRule,
-            ],
+            'by_type' => ['sometimes', 'required', 'string', new BreweryTypeRule],
             'by_ids' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
-            'exclude_types' => [
-                'sometimes',
-                'required',
-                'string',
-                new BreweryTypeRule,
-            ],
+            'exclude_types' => ['sometimes', 'required', 'string', new BreweryTypeRule],
         ]);
 
         $breweries = Brewery::query()

--- a/app/Http/Controllers/Api/V1/ListBreweries.php
+++ b/app/Http/Controllers/Api/V1/ListBreweries.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\BreweryResource;
 use App\Models\Brewery;
+use App\Rules\BreweryType as BreweryTypeRule;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
@@ -28,9 +29,19 @@ class ListBreweries extends Controller
             'by_name' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
             'by_postal' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
             'by_state' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
-            'by_type' => ['sometimes', 'required', 'string', 'min:3', 'max:100'],
+            'by_type' => [
+                'sometimes',
+                'required',
+                'string',
+                new BreweryTypeRule,
+            ],
             'by_ids' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
-            'exclude_types' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],
+            'exclude_types' => [
+                'sometimes',
+                'required',
+                'string',
+                new BreweryTypeRule,
+            ],
         ]);
 
         $breweries = Brewery::query()

--- a/app/Rules/BreweryType.php
+++ b/app/Rules/BreweryType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Rules;
+
+use App\Enums\BreweryType as BreweryTypeEnum;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class BreweryType implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $types = array_map('trim', explode(',', $value));
+
+        foreach ($types as $type) {
+            if (! BreweryTypeEnum::tryFrom($type)) {
+                $fail("The {$attribute} contains invalid brewery type: {$type}");
+            }
+        }
+    }
+}

--- a/tests/Feature/Api/V1/GetBreweries/ExcludeTypesTest.php
+++ b/tests/Feature/Api/V1/GetBreweries/ExcludeTypesTest.php
@@ -60,6 +60,7 @@ test('exclude types handles invalid type values', function () {
     ]);
 
     $response = $this->getJson('/v1/breweries?exclude_types=invalid_type');
-    $response->assertOk();
-    expect($response->json())->toHaveCount(1);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['exclude_types']);
 });

--- a/tests/Feature/Api/V1/GetBreweries/TypeFilterTest.php
+++ b/tests/Feature/Api/V1/GetBreweries/TypeFilterTest.php
@@ -29,7 +29,7 @@ test('returns breweries filtered by type', function () {
     expect($types->contains('micro'))->toBeTrue();
 });
 
-test('returns empty list for invalid brewery type', function () {
+test('returns validation error when an invalid brewery type is provided', function () {
     // Create breweries of different types
     createBreweries(5, [
         'brewery_type' => BreweryType::Micro,
@@ -42,8 +42,8 @@ test('returns empty list for invalid brewery type', function () {
     $response = $this->getJson('/v1/breweries?by_type=invalid');
 
     // Assert no matches
-    $response->assertOk()
-        ->assertJsonCount(0);
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['by_type']);
 });
 
 test('returns breweries filtered by multiple types', function () {


### PR DESCRIPTION
## 📃 Description

This PR updates `by_type` and `exclude_type` validation by assessing the value(s) against the `BreweryTypes` enum.

## 🪵 Changelog

### ➕ Added

- `BreweryType` rule to easily validate against the enum values

### ✏️ Changed

- don't return an empty result if there is an invalid value, instead throw a validation error like the current api

## 👀 Response examples

The following show the different between the existing API and the response from the new API.

### Old

```json
{"errors":["Brewery type must include one of these types: [\"micro\", \"nano\", \"regional\", \"brewpub\", \"large\", \"planning\", \"bar\", \"contract\", \"proprietor\", \"closed\"]"]}
```

New

```json
{"message":"The by_type contains invalid brewery type: invalid","errors":{"by_type":["The by_type contains invalid brewery type: invalid"]}}
```